### PR TITLE
Overhaul availability testing and add expected input languages for detector

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Translator and Language Detector APIs
 Shortname: translation
 Level: None
-Status: w3c/UD
+Status: CG-DRAFT
 Group: webml
 Repository: webmachinelearning/translation-api
 URL: https://webmachinelearning.github.io/translation-api
@@ -11,9 +11,10 @@ Abstract: The translator and langauge detector APIs gives web pages the ability 
 Markup Shorthands: markdown yes, css no
 Complain About: accidental-2119 yes, missing-example-ids yes
 Assume Explicit For: yes
-Die On: warning
-Boilerplate: omit conformance
 Default Biblio Status: current
+Boilerplate: omit conformance
+Indent: 2
+Die On: warning
 </pre>
 
 Introduction {#intro}


### PR DESCRIPTION
Add an `expectedInputLanguages` option to language detector creation API. This allows the browser to download relevant material if necessary, or fail-fast if a language the web developer needs to support is not available.

Then, remove the `capabilities()` methods and the accompanying `AI*Capabilities` classes.

* For translator, the only useful capabilities API was `(await ai.translator.capabilities()).languagePairAvailable()`. We simplify this to `await ai.translator.availability()`. This design also avoids the complexity where we have to retrieve all the availability information for every combination of options during the call to `capabilities()`, for later sync access. Now we can just retrieve the relevant information during the call to `availability()`.

  Also, by unifying on using the same options for `create()` and `availability()`, we fix #24.

* For language detector, the capabilities supplied both `(await ai.languageDetector.capabilities()).available` and `(await ai.languageDetector.capabilities()).languageAvailable()`. We simplify this into `await ai.languageDetector.availability()`, which can either take no arguments (emulating `available`) or take the same `{ expectedInputLanguages }` argument as `create()` (emulating `languageAvailable()`).

See also https://github.com/webmachinelearning/writing-assistance-apis/pull/22 and https://github.com/webmachinelearning/prompt-api/pull/69.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/translation-api/pull/31.html" title="Last updated on Dec 12, 2024, 6:25 AM UTC (0b498ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/translation-api/31/96c4724...0b498ce.html" title="Last updated on Dec 12, 2024, 6:25 AM UTC (0b498ce)">Diff</a>