### PR TITLE
Improve timing of aborting in response to AbortSignals

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -622,6 +622,8 @@ The <dfn attribute for="LanguageDetector">inputQuota</dfn> getter steps are to r
 
   1. If |compositeSignal| is [=AbortSignal/aborted=], then return [=a promise rejected with=] |compositeSignal|'s [=AbortSignal/abort reason=].
 
+  1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+
   1. Let |abortedDuringOperation| be false.
 
     <p class="note">This variable will be written to from the [=event loop=], but read from [=in parallel=].
@@ -630,9 +632,9 @@ The <dfn attribute for="LanguageDetector">inputQuota</dfn> getter steps are to r
 
     1. Set |abortedDuringOperation| to true.
 
-  1. Let |inputQuota| be [=this=]'s [=LanguageDetector/input quota=].
+    1. [=Reject=] |promise| with |compositeSignal|'s [=AbortSignal/abort reason=].
 
-  1. Let |promise| be [=a new promise=] created in [=this=]'s [=relevant realm=].
+  1. Let |inputQuota| be [=this=]'s [=LanguageDetector/input quota=].
 
   1. [=In parallel=]:
 
@@ -644,7 +646,7 @@ The <dfn attribute for="LanguageDetector">inputQuota</dfn> getter steps are to r
 
     1. [=Queue a global task=] on the [=AI task source=] given |global| to perform the following steps:
 
-      1. If |abortedDuringOperation| is true, then [=reject=] |promise| with |compositeSignal|'s [=AbortSignal/abort reason=].
+      1. If |abortedDuringOperation| is true, then abort these steps.
 
       1. Otherwise, if |result| is an [=error information=], then [=reject=] |promise| with the result of [=converting error information into an exception object=] given |result|.
 


### PR DESCRIPTION
Part of https://github.com/webmachinelearning/writing-assistance-apis/issues/63. (Since detect() does not reuse the shared infrastructure, it needs its own parallel patch.)

@nathanmemmott PTAL!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/translation-api/pull/53.html" title="Last updated on Apr 22, 2025, 6:40 AM UTC (bf78508)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/translation-api/53/a1caf65...bf78508.html" title="Last updated on Apr 22, 2025, 6:40 AM UTC (bf78508)">Diff</a>